### PR TITLE
Move IJ SDK to 141.1532.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -68,7 +68,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ CE 141.1010.3" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ CE 141.1532" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/core-plugin/google-cloud-tools-core.iml
+++ b/core-plugin/google-cloud-tools-core.iml
@@ -9,10 +9,10 @@
       <sourceFolder url="file://$MODULE_DIR$/testSrc" isTestSource="true" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="jdk" jdkName="IntelliJ CE 141.1010.3" jdkType="IDEA JDK" />
+    <orderEntry type="jdk" jdkName="IntelliJ CE 141.1532" jdkType="IDEA JDK" />
     <orderEntry type="library" exported="" scope="PROVIDED" name="gradle" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="git4idea" level="application" />
-    <orderEntry type="module-library">
+    <orderEntry type="module-library" exported="">
       <library>
         <CLASSES>
           <root url="file://$MODULE_DIR$/lib" />

--- a/google-login-plugin/google-login.iml
+++ b/google-login-plugin/google-login.iml
@@ -8,7 +8,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testSrc" isTestSource="true" />
     </content>
-    <orderEntry type="jdk" jdkName="IntelliJ CE 141.1010.3" jdkType="IDEA JDK" />
+    <orderEntry type="jdk" jdkName="IntelliJ CE 141.1532" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library" exported="">
       <library>


### PR DESCRIPTION
141.1532 has changes to support a new extensibility hook from JB for cloud debugger.

Note, you should update your build of intelliJ to make this new build.

See:  https://www.jetbrains.com/intellij-repository/releases
