### PR TITLE
Cloud Debugger Ux fixes.

### DIFF
--- a/core-plugin/resources/messages/CloudToolsBundle.properties
+++ b/core-plugin/resources/messages/CloudToolsBundle.properties
@@ -142,3 +142,4 @@ clouddebug.version.with.module.format={0} Version\:{1}
 clouddebug.versionformat=Version\:{0}
 clouddebug.invalid.state=The breakpoint could not be set because you are not attached.
 clouddebug.no.response=The server returned no breakpoint in response.
+clouddebug.new.snapshot.received=New snapshot received.

--- a/core-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
@@ -78,7 +78,7 @@ public class CloudDebugProcessStateController {
     if (myState == null) {
       throw new IllegalStateException();
     }
-    final Debugger client = CloudDebuggerClient.getCloudDebuggerClient(myState);
+    final Debugger client = CloudDebuggerClient.getLongTimeoutClient(myState);
     if (client == null) {
       LOG.warn("no client available attempting to setBreakpoint");
       Messages.showErrorDialog(myState.getProject(), GctBundle.getString("clouddebug.bad.login.message"),
@@ -143,11 +143,15 @@ public class CloudDebugProcessStateController {
   public void resolveBreakpointAsync(@NotNull final String id,
       @NotNull final ResolveBreakpointHandler handler) {
 
+    if (myFullFinalBreakpoints.containsKey(id)) {
+      handler.onSuccess(myFullFinalBreakpoints.get(id));
+      return;
+    }
     if (myState == null) {
       handler.onError(GctBundle.getString("clouddebug.invalid.state"));
       return;
     }
-    final Debugger client = CloudDebuggerClient.getCloudDebuggerClient(myState);
+    final Debugger client = CloudDebuggerClient.getLongTimeoutClient(myState);
     if (client == null) {
       LOG.warn("no client available attempting to resolveBreakpointAsync");
       handler.onError(GctBundle.getString("clouddebug.bad.login.message"));
@@ -199,7 +203,7 @@ public class CloudDebugProcessStateController {
       handler.onError(GctBundle.getString("clouddebug.invalid.state"));
       return;
     }
-    final Debugger client = CloudDebuggerClient.getCloudDebuggerClient(myState);
+    final Debugger client = CloudDebuggerClient.getLongTimeoutClient(myState);
     if (client == null) {
       LOG.warn("no client available attempting to setBreakpoint");
       handler.onError(GctBundle.getString("clouddebug.bad.login.message"));
@@ -298,7 +302,7 @@ public class CloudDebugProcessStateController {
       LOG.error("no state available attempting to checkForChanges");
       return;
     }
-    final Debugger client = CloudDebuggerClient.getCloudDebuggerClient(myState);
+    final Debugger client = CloudDebuggerClient.getLongTimeoutClient(myState);
     if (client == null) {
       LOG.info("no client available attempting to checkForChanges");
       return;

--- a/core-plugin/src/com/google/gct/idea/debugger/ProjectRepositoryValidator.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/ProjectRepositoryValidator.java
@@ -177,7 +177,7 @@ public class ProjectRepositoryValidator {
   @Nullable
   protected Debugger getCloudDebuggerClient() {
     if (myCloudDebuggerClient == null) {
-      myCloudDebuggerClient = CloudDebuggerClient.getCloudDebuggerClient(myProcessState);
+      myCloudDebuggerClient = CloudDebuggerClient.getLongTimeoutClient(myProcessState);
     }
     return myCloudDebuggerClient;
   }

--- a/core-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
@@ -412,7 +412,7 @@ public class CloudAttachDialog extends DialogWrapper {
 
       myCredentialedUser = credentialedUser;
       myCloudDebuggerClient =
-        myCredentialedUser != null ? CloudDebuggerClient.getCloudDebuggerClient(myCredentialedUser.getEmail()) : null;
+        myCredentialedUser != null ? CloudDebuggerClient.getLongTimeoutClient(myCredentialedUser.getEmail()) : null;
 
 
       return myCloudDebuggerClient;


### PR DESCRIPTION
Clicking quickly on snapshot list queues selection.
   We queued up each background async resolve
   which could result in queued selections.
   Now we throw away old selections.
Expected Auto-Nav to new Snapshots
   Changed the Ux to make new items more obvious
   and removed autoselect.
Set Verified after getting a breakpoint from ListBreakpoints
  Removes the possibility of a bp going from verified to error.
Cloud Debugger Ux - Change Polling to use tokens
  Perf fix to reduce load on server.
