### PR TITLE
un .gitignoring project libs so that the project can have gradle and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ google-login-plugin/build/
 idea-IC/
 .idea/gradle.xml
 .idea/codeStyleSettings.xml
-.idea/libraries/*
-


### PR DESCRIPTION
…git4idea libs setup robustly across users
