### PR TITLE
use javac2 to compile java sources for plugins

### DIFF
--- a/core-plugin/build.gradle
+++ b/core-plugin/build.gradle
@@ -1,3 +1,4 @@
+apply from: '../scripts/javac2.gradle'
 def ideaHome = '../idea-IC/'
 def pluginName = 'google-cloud-tools-core'
 
@@ -38,21 +39,10 @@ dependencies {
     testRuntime files(ideaHome + '/lib/trove4j.jar')
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs 'src', 'resources'
-        }
-        resources {
-            srcDir 'resources'
-        }
-    }
-    test {
-        java {
-            srcDirs 'testSrc'
-        }
-    }
-}
+// **replace** default sourceSets with idea layout
+sourceSets.main.java.srcDirs = ['src', 'resources']
+sourceSets.main.resources.srcDirs = ['resources']
+sourceSets.test.java.srcDirs = ['testSrc']
 
 test {
     testLogging {

--- a/google-login-plugin/build.gradle
+++ b/google-login-plugin/build.gradle
@@ -1,5 +1,6 @@
 // see https://github.com/JetBrains/gradle-intellij-plugin
 
+apply from: '../scripts/javac2.gradle'
 def ideaLib = '../idea-IC/lib/'
 
 dependencies {
@@ -33,21 +34,10 @@ dependencies {
     testCompile 'org.mockito:mockito-all:1.9.5'
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs 'src', 'resources'
-        }
-        resources {
-            srcDir 'resources'
-        }
-    }
-    test {
-        java {
-            srcDirs 'testSrc'
-        }
-    }
-}
+// **replace** default sourceSets with idea layout
+sourceSets.main.java.srcDirs = ['src', 'resources']
+sourceSets.main.resources.srcDirs = ['resources']
+sourceSets.test.java.srcDirs = ['testSrc']
 
 // because plugin.xml doesn't live in resources
 jar {

--- a/scripts/javac2.gradle
+++ b/scripts/javac2.gradle
@@ -1,0 +1,43 @@
+/**
+ * Script that replaces javac with javac2 by removing all actions in compileJava
+ * and drops in a single action that calls the javac2 ant task defined by JetBrains
+ */
+def javac2Lib = '../idea-IC/lib'
+
+configurations {
+    javac2
+}
+
+dependencies {
+    javac2 files(javac2Lib + '/javac2.jar')
+    javac2 files(javac2Lib + '/jdom.jar')
+    javac2 files(javac2Lib + '/asm.jar')
+    javac2 files(javac2Lib + '/asm-all.jar')
+    javac2 files(javac2Lib + '/asm-commons.jar')
+    javac2 files(javac2Lib + '/jgoodies-forms.jar')
+}
+
+// overwrite compileJava to use intellij javac2
+// https://grahamedgecombe.com/blog/2013/04/03/using-intellij-ideas-javac2-in-gradle
+// https://discuss.gradle.org/t/replacing-tasks-overwrite-true-does-not-work-in-1-5/2148/3
+compileJava {
+    actions = []
+    doLast {
+        project.sourceSets.main.output.classesDir.mkdirs()
+        ant.taskdef name: 'javac2', 
+                    classname: 'com.intellij.ant.Javac2', 
+                    classpath: configurations.javac2.asPath
+        ant.javac2 srcDir: project.sourceSets.main.java.srcDirs.join(':'),
+                   classpath: project.sourceSets.main.compileClasspath.asPath,
+                   destDir: project.sourceSets.main.output.classesDir,
+                   source: sourceCompatibility,
+                   target: targetCompatibility,
+                   includeAntRuntime: false
+                   /** other flags
+                    * optimize = "on/off"
+                    * deprecation = "on/off"
+                    * debugLevel = "something"
+                    * debug = "on/off"
+                    */
+    }
+}


### PR DESCRIPTION
this change uses JetBrains javac2 compiler to build the plugins,
taking care of any JetBrains specific manipulation for plugin classes
