### PR TITLE
Moving and renaming the debugger initializer

### DIFF
--- a/core-plugin/src/META-INF/plugin.xml
+++ b/core-plugin/src/META-INF/plugin.xml
@@ -19,7 +19,7 @@
 
   <application-components>
     <component>
-      <implementation-class>com.google.gct.idea.debugger.DebuggerInitializationComponent</implementation-class>
+      <implementation-class>com.google.gct.idea.CloudToolsCoreInitializationComponent</implementation-class>
     </component>
   </application-components>
 

--- a/core-plugin/src/com/google/gct/idea/CloudToolsCoreInitializationComponent.java
+++ b/core-plugin/src/com/google/gct/idea/CloudToolsCoreInitializationComponent.java
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.gct.idea.debugger;
+package com.google.gct.idea;
+
+import com.google.gct.idea.debugger.CloudDebugConfigType;
+import com.google.gct.idea.debugger.CloudDebugRunConfiguration;
 
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.openapi.components.ApplicationComponent;
@@ -23,9 +26,9 @@ import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Conditionally registers our {@link CloudDebugRunConfiguration} if our flag is on.
+ * Performs runtime initialization for the GCT plugin.
  */
-public class DebuggerInitializationComponent implements ApplicationComponent {
+public class CloudToolsCoreInitializationComponent implements ApplicationComponent {
   @Override
   public void disposeComponent() {
 
@@ -34,7 +37,7 @@ public class DebuggerInitializationComponent implements ApplicationComponent {
   @NotNull
   @Override
   public String getComponentName() {
-    return "DebuggerInitializationComponent";
+    return "CloudToolsCoreInitializationComponent";
   }
 
   @Override


### PR DESCRIPTION
I'm moving and renaming this to have one place to perform plugin initialization tasks.
