### PR TITLE
Disable flaky test

### DIFF
--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsFeedbackActionTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsFeedbackActionTest.java
@@ -30,6 +30,7 @@ import com.google.common.net.UrlEscapers;
 import com.intellij.ide.browsers.BrowserLauncher;
 import java.io.File;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +38,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
 /** Tests for {@link CloudToolsFeedbackAction}. */
+@Ignore
 @RunWith(JUnit4.class)
 public final class CloudToolsFeedbackActionTest {
 


### PR DESCRIPTION
fixes #2071 

This test is very flaky - both locally and on Kokoro. @Ignore'ing it for know until we can figure out why. Its a pretty self contained small piece of functionality (the feedback button) so I feel ok doing this for now.