### PR TITLE
Fix K8s example Jib version to work with the latest Skaffold versions.

### DIFF
--- a/kubernetes/examples/hello-spring-boot/pom.xml
+++ b/kubernetes/examples/hello-spring-boot/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>1.2.0</version>
+                <version>1.4.0</version>
                 <configuration>
                     <container>
                         <jvmFlags>


### PR DESCRIPTION
Doesn't work as of now, since 1.3+ is required for the latest Skaffold Jib-based builds.