### PR TITLE
Adding an option for the IDE version in the new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,8 @@
 
 ### Aditional Information
 
-- Cloud Code IntelliJ version (Settings > Plugins > Cloud Code): 
+- IDE version:
+- Cloud Code version (Settings > Plugins > Cloud Code): 
 - Cloud SDK (Settings > Cloud Code > Cloud SDK)
   - Are you allowing the plugin to manage the Cloud SDK: 
   - Version of the Cloud SDK:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,6 +8,7 @@
 
 ### Aditional Information
 
+- IDE type (e.g. IntelliJ, Pycharm):
 - IDE version:
 - Cloud Code version (Settings > Plugins > Cloud Code): 
 - Cloud SDK (Settings > Cloud Code > Cloud SDK)


### PR DESCRIPTION
Update to https://github.com/GoogleCloudPlatform/cloud-code-intellij/pull/2797